### PR TITLE
Potential fix for code scanning alert no. 111: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/Pages/ViewEditPost.jsx
+++ b/frontend/src/Pages/ViewEditPost.jsx
@@ -47,11 +47,21 @@ function ViewEditPost() {
   // console.log("PostId", PostId);
 
   const onImageChange = (e) => {
-    console.log(e.target.files[0]);
-    const file = e.target.files[0];
+    const file = e.target.files && e.target.files[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (!file.type || !file.type.startsWith("image/")) {
+      toast.error("Please select a valid image file.");
+      setPreviewImage(null);
+      setImage(null);
+      return;
+    }
 
     setPreviewImage(URL.createObjectURL(file)); // Show preview
-    setImage(e.target.files[0]);
+    setImage(file);
   };
 
   const handleSubmit = async (e) => {

--- a/frontend/src/Pages/ViewEditPost.jsx
+++ b/frontend/src/Pages/ViewEditPost.jsx
@@ -54,7 +54,7 @@ function ViewEditPost() {
     }
 
     if (!file.type || !file.type.startsWith("image/")) {
-      toast.error("Please select a valid image file.");
+      toast.error("Format Error","Please select a valid image file.");
       setPreviewImage(null);
       setImage(null);
       return;


### PR DESCRIPTION
Potential fix for [https://github.com/YUGESHKARAN/Tech-Community-App/security/code-scanning/111](https://github.com/YUGESHKARAN/Tech-Community-App/security/code-scanning/111)

To fix this safely without changing functionality, validate the selected file before calling `URL.createObjectURL` and only accept real image MIME types. If invalid, clear preview/image state and notify the user. This prevents unsafe or unexpected file content from flowing into the rendered `src`.

Best targeted change in `frontend/src/Pages/ViewEditPost.jsx`:
- Update `onImageChange` to:
  - safely read first file,
  - check `file.type` starts with `"image/"`,
  - reject invalid files with a toast and reset state,
  - only then call `URL.createObjectURL(file)` and set state.
- Keep line 286 rendering logic intact; with validated state, it remains safe.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
