### PR TITLE
Potential fix for code scanning alert no. 135: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/Pages/ProfilePage.jsx
+++ b/frontend/src/Pages/ProfilePage.jsx
@@ -674,7 +674,7 @@ function ProfilePage() {
                                 setCustomTitle("");
                                 setLinkId(null);
                               } else if (titleToUse) {
-                                toast.error("Please enter a valid http(s) URL.");
+   toast.error("Invalid URL","Please enter a valid http(s) URL.");
                               }
                             }}
                             className="self-start px-4 py-2 text-xs font-medium rounded-lg bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 hover:bg-emerald-500/20 transition-colors"

--- a/frontend/src/Pages/ProfilePage.jsx
+++ b/frontend/src/Pages/ProfilePage.jsx
@@ -36,6 +36,18 @@ function ProfilePage() {
   const [previewImage, setPreviewImage] = useState(null);
   const [bioDescription, setBioDescription] = useState("");
 
+  const sanitizeUrl = (rawUrl) => {
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        return parsed.toString();
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  };
+
   const [links, setLinks] = useState([]);
   const [currentLinkTitle, setCurrentLinkTitle] = useState("");
   const [currentLinkUrl, setCurrentLinkUrl] = useState("");
@@ -646,10 +658,13 @@ function ProfilePage() {
                                 currentLinkTitle === "Others"
                                   ? customTitle?.trim()
                                   : currentLinkTitle.trim();
-                              if (titleToUse && currentLinkUrl.trim()) {
+                              const sanitizedUrl = sanitizeUrl(
+                                currentLinkUrl.trim()
+                              );
+                              if (titleToUse && sanitizedUrl) {
                                 const newLink = {
                                   title: titleToUse,
-                                  url: currentLinkUrl.trim(),
+                                  url: sanitizedUrl,
                                   id: linkId,
                                 };
                                 setLinks([...links, newLink]);
@@ -658,6 +673,8 @@ function ProfilePage() {
                                 setCurrentLinkUrl("");
                                 setCustomTitle("");
                                 setLinkId(null);
+                              } else if (titleToUse) {
+                                toast.error("Please enter a valid http(s) URL.");
                               }
                             }}
                             className="self-start px-4 py-2 text-xs font-medium rounded-lg bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 hover:bg-emerald-500/20 transition-colors"


### PR DESCRIPTION
Potential fix for [https://github.com/YUGESHKARAN/Tech-Community-App/security/code-scanning/135](https://github.com/YUGESHKARAN/Tech-Community-App/security/code-scanning/135)

Use strict URL validation and allowlisting before adding links to state, so untrusted DOM text is never rendered into `href` unless safe.

Best fix in this file:
1. Add a small helper (inside `ProfilePage`) to normalize and validate URLs using `new URL(...)`.
2. Allow only safe protocols (for example `http:` and `https:`).
3. In the existing add-link handler (around lines 645–655), sanitize `currentLinkUrl.trim()` first.
4. Only create/push `newLink` when both title and sanitized URL are valid.
5. Optionally show a toast error when invalid.

This preserves functionality (users still add normal links) while blocking dangerous schemes and addressing both alert variants since both inputs feed the same `currentLinkUrl` flow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
